### PR TITLE
feat: add smoother drawing

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ model_path = os.path.join(current_path, 'models/120.pt')
 pen_color = (255,0,0)
 eraser_size = 80
 pen_size = 10
+intermediate_step_gap = 4
 
 cap = cv2.VideoCapture(cam_number)
 
@@ -125,7 +126,7 @@ while True :
                     x_distance = pos[0] - prev_pos[0]
                     y_distance = pos[1] - prev_pos[1]
                     distance = (x_distance ** 2 + y_distance ** 2) ** 0.5
-                    num_step_points = int(distance) - 1
+                    num_step_points = int(distance) // intermediate_step_gap - 1
                     if num_step_points > 0:
                         x_normalized = x_distance / distance
                         y_normalized = y_distance / distance


### PR DESCRIPTION
resolves #12

It's possible my webcam just isn't ideal but I ran into a lot of tracking issues both with this "smooth drawing algorithm" implemented and without.

Without:
![image](https://user-images.githubusercontent.com/28541089/135757466-9b64d7ef-7c94-4e07-8b64-5c6f45fa9b8b.png)

With:
![image](https://user-images.githubusercontent.com/28541089/135757472-289e4bc5-eefe-4a0c-b9e4-b13677e2c88c.png)

Very often it would mix up gestures and sometimes when drawing it would draw in the wrong spot. For example, sometimes it would draw on the red dot below the tip of the index finger:
![image](https://user-images.githubusercontent.com/28541089/135757634-69f0be87-fcf9-43cd-a819-ffbde511122a.png)

Because the smoothing algorithm works by filling in the gaps between the previous position and the current position this issue is  exacerbated since it turns one misplaced circle into several.
This can be seen in these seemingly random extra strokes:
![image](https://user-images.githubusercontent.com/28541089/135757729-25a243d6-9847-487f-8fab-0283de22b215.png)
